### PR TITLE
Fix `Icon` field in the .desktop file

### DIFF
--- a/src/icons/dsda-Launcher.desktop
+++ b/src/icons/dsda-Launcher.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Name=DSDA-Launcher
 Comment=launcher for a enhanced clone of the classic first-person shooter Doom
-Icon=dsda-doom
+Icon=dsda-launcher
 TryExec=dsda-doom
 Exec=dsda-launcher
 Categories=Game;ActionGame;


### PR DESCRIPTION
Currently the desktop file is trying to get the `dsda-doom` icon which is not provided.