### PR TITLE
Update Qt to 6.8 LTS on Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,11 +73,10 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4.1.1
         with:
-          aqtversion: '==3.1.*'
-          version: '6.2.0'
+          version: '6.8.*'
           host: 'linux'
           target: 'desktop'
-          arch: 'gcc_64'
+          arch: 'linux_gcc_64'
           tools: 'tools_opensslv3_src'
           
       - name: build


### PR DESCRIPTION
This should make the AppImage not crash on startup if update checks are enabled and thus fix #10 :)

There's a build made from this change [over on my copy of the repo](https://github.com/fpiesche/dsda-launcher/actions/runs/25005746075) for testing purposes.